### PR TITLE
chore: update backstage catalog entities

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,12 +1,9 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Location
 metadata:
-  name: tradiecore-public-documentation
-  description: Tradiecore public documentation
-  annotations:
-    github.com/project-slug: hipagesgroup/tradiecore-public-documentation
+  name: tradiecore-public-documentation-apps
+  description: Applications managed within the tradiecore-public-documentation repo.
 spec:
-  type: documentation
-  lifecycle: production
-  system: tradiecore
-  owner: job-management-experience
+  targets:
+    - ./catalog/*.yaml
+    - ./catalog/**/*.yaml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: tradiecore-public-documentation-apps
+  name: tradiecore-public-documentation
   description: Applications managed within the tradiecore-public-documentation repo.
 spec:
   targets:

--- a/catalog/apps/tradiecore-public-documentation.yaml
+++ b/catalog/apps/tradiecore-public-documentation.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: tradiecore-public-documentation
+  title: "Tradiecore Public Documentation"
+  description: Tradiecore public documentation
+  annotations:
+    github.com/project-slug: hipagesgroup/tradiecore-public-documentation
+    github.com/team-slug: job-management-experience
+    hipages/use-techdocs-of: system:tradiecore
+spec:
+  type: documentation
+  lifecycle: production
+  system: tradiecore
+  owner: job-management-experience

--- a/catalog/apps/tradiecore-public-documentation.yaml
+++ b/catalog/apps/tradiecore-public-documentation.yaml
@@ -7,7 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: hipagesgroup/tradiecore-public-documentation
     github.com/team-slug: job-management-experience
-    hipages/use-techdocs-of: system:tradiecore
+    backstage.io/techdocs-entity: system:default/tradiecore
+  tags:
+    - repo
 spec:
   type: documentation
   lifecycle: production


### PR DESCRIPTION
## Summary

- Convert `catalog-info.yaml` from a flat `Component` entity to a proper `Location` entity (structural requirement)
- Move `Component` entity to `catalog/apps/tradiecore-public-documentation.yaml`
- Add missing `title: "Tradiecore Public Documentation"`
- Add `github.com/team-slug: job-management-experience` annotation
- Add `hipages/use-techdocs-of: system:tradiecore` annotation so this component shares TechDocs from the main tradiecore system

## Test plan

- [ ] Verify `tradiecore-public-documentation` Component still appears in Backyard after merge
- [ ] Verify it is still associated with the `tradiecore` system and `job-management-experience` team